### PR TITLE
Fix typo on the SH equation

### DIFF
--- a/Assets/LightProbeUtility.cs
+++ b/Assets/LightProbeUtility.cs
@@ -46,12 +46,12 @@ public static class LightProbeUtility
         // Quadratic polynomials
         for (var i = 0; i < 3; i++)
             material.SetVector(_idSHB[i], new Vector4(
-                sh[i, 4], sh[i, 6], sh[i, 5] * 3, sh[i, 7]
+                sh[i, 4], sh[i, 5], sh[i, 6] * 3, sh[i, 7]
             ));
 
         // Final quadratic polynomial
         material.SetVector(_idSHC, new Vector4(
-            sh[0, 8], sh[2, 8], sh[1, 8], 1
+            sh[0, 8], sh[1, 8], sh[2, 8], 1
         ));
     }
 


### PR DESCRIPTION
The SH values didn't match with Unity's.
After searching for a different equation found
https://github.com/Jammie506/GameEngines2Project/blob/c96d3b4cb05a895caa40b50535b01e121fe331c4/Space%20Battle/Library/PackageCache/com.unity.rendering.hybrid%400.10.0-preview.21/Unity.Rendering.Hybrid/Probes/AmbientProbeUpdateSystem.cs
With this values it does match the values Unity calculates for the lightprobes.